### PR TITLE
Fix some presets, and add new ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,24 @@ The prayer times can be configured in the following ways:
 
 You can add a safety offset to all times via the `awqat-prayer-safety-offsets` variable. For example, to have sunrise be one minute sooner, Dhuhr two minutes later, and Maghrib one minute later you can add `(setq awqat-prayer-safety-offsets '(0.0 -1.0 2.0 0.0 1.0 0.0))`.
 
-There are presets with the angles for various organizations. You can call these functions to configure the various variables. The following presets exist: `awqat-set-preset-muslim-pro`, `awqat-set-preset-muslim-world-league`, `awqat-set-preset-karachi-university-of-islamic-sciences`, `awqat-set-preset-umm-al-qura`, `awqat-set-preset-jakim`, `awqat-set-preset-spiritual-administration-of-musilms-russia`, `awqat-set-preset-union-des-organisations-islamiques-de-france`, `awqat-set-preset-isna`. Please note that these presets **only** configure the angles for Isha and Fajr and may or may not reflect the actual times of the organization.
+There are presets with the angles for various organizations. You can call these
+functions to configure the various variables. The following presets exist:
+ 
+- `awqat-set-preset-muslim-pro`
+- `awqat-set-preset-muslim-world-league`
+- `awqat-set-preset-karachi-university-of-islamic-sciences`
+- `awqat-set-preset-umm-al-qura`
+- `awqat-set-preset-jakim`
+- `awqat-set-preset-spiritual-administration-of-musilms-russia`
+- `awqat-set-preset-french-muslims`
+- `awqat-set-preset-isna`
+- `awqat-set-preset-egyptian-general-authority-of-survey`
+- `awqat-set-preset-kuwait`
+- `awqat-set-preset-singapore`
+- `awqat-set-preset-diyanet-turkey`
+- `awqat-set-preset-uae`
+
+Please note that these presets (except `awqat-set-preset-umm-al-qura`) **only** configure the angles for Isha and Fajr and may or may not reflect the actual times of the organization.
 
 The following is an example configuration:
 ```lisp

--- a/awqat.el
+++ b/awqat.el
@@ -137,9 +137,9 @@ This is not zero as when angle is 0, sun is still visible.")
   "Set the calculation method to be simmilar to the SAMR."
   (awqat--preset-with-angles -16.0 -15.0))
 
-(defun awqat-set-preset-union-des-organisations-islamiques-de-france ()
-  "Set the calculation method to be simmilar to the Union des Organisations Islamiques de France."
-  (awqat--preset-with-angles -16.0 -15.0))
+(defun awqat-set-preset-french-muslims ()
+  "Set the calculation method to be simmilar to the French Muslims (former: Union des Organisations Islamiques de France)."
+  (awqat--preset-with-angles -12.0 -12.0))
 
 (defun awqat-set-preset-isna ()
   "Set the calculation method to be similar to ISNA."

--- a/awqat.el
+++ b/awqat.el
@@ -137,6 +137,10 @@ This is not zero as when angle is 0, sun is still visible.")
   "Use the calculation method used in Kuwait."
   (awqat--preset-with-angles -18.0 -17.5))
 
+(defun awqat-set-preset-singapore ()
+  "Use the calculation method defined by the Majlis Ugama Islam Singapura."
+  (awqat--preset-with-angles -20.0 -18.0))
+
 (defun awqat-set-preset-jakim ()
   "Use the calculation method defined by the Department of Islamic Development Malaysia (JAKIM)."
   (awqat--preset-with-angles -20.0 -18.0))

--- a/awqat.el
+++ b/awqat.el
@@ -145,6 +145,10 @@ This is not zero as when angle is 0, sun is still visible.")
   "Use the calculation method defined by the Directorate of Religious Affairs, Turkey (Diyanet İşleri Başkanlığı)."
   (awqat--preset-with-angles -18.0 -17.0))
 
+(defun awqat-set-preset-uae ()
+  "Use the calculation method used in UAE."
+  (awqat--preset-with-angles -18.2 -18.2))
+
 (defun awqat-set-preset-jakim ()
   "Use the calculation method defined by the Department of Islamic Development Malaysia (JAKIM)."
   (awqat--preset-with-angles -20.0 -18.0))

--- a/awqat.el
+++ b/awqat.el
@@ -114,35 +114,35 @@ This is not zero as when angle is 0, sun is still visible.")
   (setq awqat-isha-angle -13.94))
 
 (defun awqat-set-preset-muslim-pro ()
-  "Set the calculation method to be simmilar to the Muslim Pro app."
+  "Use the calculation method defined by the Muslim Pro app."
   (awqat--preset-with-angles -18.13 -16.3))
 
 (defun awqat-set-preset-muslim-world-league ()
-  "Set the calculation method to be simmilar to the muslim world league."
+  "Use the calculation method defined by the Muslim World League."
   (awqat--preset-with-angles -18.0 -17))
 
 (defun awqat-set-preset-karachi-university-of-islamic-sciences ()
-  "Set the calculation method to be simmilar to the karachi university of islamic sciences."
+  "Use the calculation method defined by the Karachi University of Islamic Sciences (KUIS)."
   (awqat--preset-with-angles -18.0 -18.0))
 
 (defun awqat-set-preset-umm-al-qura ()
-  "Set the calculation method to be simmilar to umm al qura."
+  "Use the calculation method defined by Umm al-Qura University, Makkah."
   (awqat--preset-with-angles -18.5 -19.0))
 
 (defun awqat-set-preset-jakim ()
-  "Set the calculation method to be simmilar to JAKIM."
+  "Use the calculation method defined by the Department of Islamic Development Malaysia (JAKIM)."
   (awqat--preset-with-angles -20.0 -18.0))
 
-(defun awqat-set-preset-spiritual-administration-of-musilms-russia ()
-  "Set the calculation method to be simmilar to the SAMR."
+(defun awqat-set-preset-spiritual-administration-of-muslims-russia ()
+  "Use the calculation method defined by the Spiritual Administration of Muslims, Russia (SAMR)."
   (awqat--preset-with-angles -16.0 -15.0))
 
 (defun awqat-set-preset-french-muslims ()
-  "Set the calculation method to be simmilar to the French Muslims (former: Union des Organisations Islamiques de France)."
+  "Use the calculation method defined by the French Muslims (former: Union des Organisations Islamiques de France)."
   (awqat--preset-with-angles -12.0 -12.0))
 
 (defun awqat-set-preset-isna ()
-  "Set the calculation method to be similar to ISNA."
+  "Use the calculation method defined by the Islamic Society of North America (ISNA)."
   (awqat--preset-with-angles -15.0 -15.0))
 
 (defun awqat--preset-with-angles (fajr isha)

--- a/awqat.el
+++ b/awqat.el
@@ -141,6 +141,10 @@ This is not zero as when angle is 0, sun is still visible.")
   "Use the calculation method defined by the Majlis Ugama Islam Singapura."
   (awqat--preset-with-angles -20.0 -18.0))
 
+(defun awqat-set-preset-diyanet-turkey ()
+  "Use the calculation method defined by the Directorate of Religious Affairs, Turkey (Diyanet İşleri Başkanlığı)."
+  (awqat--preset-with-angles -18.0 -17.0))
+
 (defun awqat-set-preset-jakim ()
   "Use the calculation method defined by the Department of Islamic Development Malaysia (JAKIM)."
   (awqat--preset-with-angles -20.0 -18.0))

--- a/awqat.el
+++ b/awqat.el
@@ -129,6 +129,10 @@ This is not zero as when angle is 0, sun is still visible.")
   "Use the calculation method defined by Umm al-Qura University, Makkah."
   (awqat--preset-with-angles -18.5 -19.0))
 
+(defun awqat-set-preset-egyptian-general-authority-of-survey ()
+  "Use the calculation method defined by the Egyptian General Authority of Survey."
+  (awqat--preset-with-angles -19.5 -17.5))
+
 (defun awqat-set-preset-jakim ()
   "Use the calculation method defined by the Department of Islamic Development Malaysia (JAKIM)."
   (awqat--preset-with-angles -20.0 -18.0))

--- a/awqat.el
+++ b/awqat.el
@@ -204,6 +204,16 @@ This is not zero as when angle is 0, sun is still visible.")
   (setq awqat-fajr-angle nil)
   (setq awqat-isha-angle nil))
 
+(defun awqat-set-preset-one-seventh-of-night ()
+  "Use the calculation method used in higher latitudes (One-seventh of night method)."
+  (setq awqat--prayer-funs (list #'awqat--prayer-fajr-one-seventh-of-night
+                                 #'awqat--prayer-sunrise
+                                 #'awqat--prayer-dhuhr
+                                 #'awqat--prayer-asr
+                                 #'awqat--prayer-maghrib
+                                 #'awqat--prayer-isha-one-seventh-of-night))
+  (setq awqat-fajr-angle nil)
+  (setq awqat-isha-angle nil))
 
 ;;; UI/Interactive functions and helpers.
 
@@ -353,6 +363,15 @@ This is not zero as when angle is 0, sun is still visible.")
     (list (- sunrise awqat-fajr-before-offset)
           timezone)))
 
+(defun awqat--prayer-fajr-one-seventh-of-night (date)
+  "Calculate the time of fajr for a given DATE.
+The one-seventh of night method is an approximation used in higher latitudes during the abnormal period."
+  (when (< -48.5 calendar-latitude 48.5)
+    (warn "This method should only be used in latitudes beyond 48.5°N and 48.5°S."))
+
+  (let ((offset (/ (awqat-duration-of-night date) 7.0)))
+    (awqat--prayer-fajr-from-sunrise date offset)))
+
 (defun awqat--prayer-fajr-midnight (date)
   "Calculate the time of fajr for a given DATE.
 The midnight method is an approximation used in higher latitudes during the abnormal period.
@@ -433,6 +452,15 @@ If `awqat-asr-hanafi' is non-nil, use double the length of noon shadow."
 The midnight method is an approximation used in higher latitudes during the abnormal period.
 It defines the Isha and Fajr times to be the same, starting at the midnight between sunset and sunrise."
   (awqat--prayer-fajr-midnight date))
+
+(defun awqat--prayer-isha-one-seventh-of-night (date)
+  "Return the Isha time for a given DATE.
+The one-seventh of night method is an approximation used in higher latitudes during the abnormal period."
+  (when (< -48.5 calendar-latitude 48.5)
+    (warn "This method should only be used in latitudes beyond 48.5°N and 48.5°S."))
+
+  (let ((offset (/ (awqat-duration-of-night date) 7.0)))
+    (awqat--prayer-isha-from-sunset date offset)))
 
 ;;; Time Calculations --------------------------------------------------------------------
 

--- a/awqat.el
+++ b/awqat.el
@@ -35,6 +35,7 @@
 (require 'solar)
 (require 'calendar)
 (require 'cal-islam)
+(require 's)
 
 (defun calendar-islamic-from-gregorian (&optional date)
   (calendar-islamic-from-absolute
@@ -607,6 +608,9 @@ If FLAG is 'skip then return empty string."
 (defvar awqat-warning-duration 0.75)
 (defvar awqat-danger-duration 0.33)
 
+(defvar awqat-mode-line-format
+  "﴾${hours}h${minutes}m>${prayer}﴿ ")
+
 (defface awqat-warning-face
   '((t (:inherit warning)))
   "Face used to show a somewhat short duration of time."
@@ -631,7 +635,7 @@ If FLAG is 'skip then return empty string."
              (h (floor time-remaining))
              (m (floor (* (mod time-remaining 1) 60)))
              (face (awqat--get-face-from-duration time-remaining))
-             (message (format "﴾%dh%dm>%s﴿ " h m name))
+             (message (s-format awqat-mode-line-format 'aget (list (cons "prayer" name) (cons "hours" h) (cons "minutes" m))))
              (len (length message)))
         (add-face-text-property 0 len face t message)
         (setq awqat-mode-line-string message)))

--- a/awqat.el
+++ b/awqat.el
@@ -34,6 +34,12 @@
 
 (require 'solar)
 (require 'calendar)
+(require 'cal-islam)
+
+(defun calendar-islamic-from-gregorian (&optional date)
+  (calendar-islamic-from-absolute
+   (calendar-absolute-from-gregorian
+    (or date (calendar-current-date)))))
 
 (defgroup awqat nil
   "Programming game involving tiled WAT and YAML code cells."
@@ -127,7 +133,18 @@ This is not zero as when angle is 0, sun is still visible.")
 
 (defun awqat-set-preset-umm-al-qura ()
   "Use the calculation method defined by Umm al-Qura University, Makkah."
-  (awqat--preset-with-angles -18.5 -19.0))
+  (setq awqat--prayer-funs (list #'awqat--prayer-fajr
+                                 #'awqat--prayer-sunrise
+                                 #'awqat--prayer-dhuhr
+                                 #'awqat--prayer-asr
+                                 #'awqat--prayer-maghrib
+                                 (lambda (date)
+                                   (let ((maghrib-time (awqat--prayer-maghrib date))
+                                         (ramadan-p (eq 9 (car (calendar-islamic-from-gregorian)))))
+                                     (list (+ (car maghrib-time) (if ramadan-p 2.0 1.5))
+                                           (cadr maghrib-time))))))
+  (setq awqat-fajr-angle -18.5)
+  (setq awqat-isha-angle nil))
 
 (defun awqat-set-preset-egyptian-general-authority-of-survey ()
   "Use the calculation method defined by the Egyptian General Authority of Survey."

--- a/awqat.el
+++ b/awqat.el
@@ -133,6 +133,10 @@ This is not zero as when angle is 0, sun is still visible.")
   "Use the calculation method defined by the Egyptian General Authority of Survey."
   (awqat--preset-with-angles -19.5 -17.5))
 
+(defun awqat-set-preset-kuwait ()
+  "Use the calculation method used in Kuwait."
+  (awqat--preset-with-angles -18.0 -17.5))
+
 (defun awqat-set-preset-jakim ()
   "Use the calculation method defined by the Department of Islamic Development Malaysia (JAKIM)."
   (awqat--preset-with-angles -20.0 -18.0))


### PR DESCRIPTION
# Summary
This PR includes several fixes and improvements.

## 1. Fix the angle for the Union des Organisations Islamiques de France
The right angle used by the 'French Muslims' (formerly known as _Union des Organisations Islamiques de France_) is 12° for both Fajr and Isha (references below).

I checked the times against my [abougouffa/pyIslam](https://github.com/abougouffa/pyIslam) library, and the mobile app I'm using. It gives correct times with 12°.

## 2. Fix a typo, and added some useful information to presets descriptions.
## 3. Add several presets
- Egyptian General Authority of Survey
- Kuwait
- Majlis Ugama Islam Singapura
- Directorate of Religious Affairs, Turkey (Diyanet İşleri Başkanlığı)
- UAE

## 4. Fix Umm al-Qura University preset
As I described in issue #7, Umm al-Qura's method do not use an angle based calculation for Isha, instead, it adds a fixed amount of time after the Maghrib. The amount to be added is defined as follows:
- `ISHA_TIME = MAGHRIB_TIME + (120 MINUTES if CURRENT_MONTH=RAMADAN else 90 MINUTES)`

## 5. Basic implementation of Midnight and One-Seventh of night methods
This implements the Midnight and One-Seventh of night methods, as described in literature [[Odeh2009](https://www.astronomycenter.net/pdf/2009_High_Latitude.pdf), [Guessoum2010](https://www.astronomycenter.net/pdf/guessoum_2010.pdf)].

#### TODO
Calculate or determine if we are in the abnormal period or not. Currently, the method should be selected by the user manually. But it would be nicer to provide an angle based alternative in the normal period (when the astronomical signs of isha and fajr are visible.)

## 6. Add a way to format the mode line displayed string
In my Emacs installation, the Unicode symbols used in mode line are not displayed correctly. And to be honest, I didn't like the default format. 

![Screenshot_20220510_000251](https://user-images.githubusercontent.com/3716399/167506118-cf6fd411-fbd3-4279-a285-ba95053c8e7d.png)

So I would like to see something like this in upstream, so I can customize my mode line message. 

I added a variable named `awqat-mode-line-format` to hold the format string. The format string is very simple, it can contain an arbitrary text with `${hours}`, `${minutes}`, and `${prayer}`. The default value of `awqat-mode-line-format` expands to a string identical to the current format, so people upgrading `awqat.el` won't notice any difference until they customize their formatting string.

## REFERENCES
- [French Muslims on Wikipedia](https://en.wikipedia.org/wiki/French_Muslims)
- [Latitude for calculation of Isha and Fajr prayer times (in French) _(the text announcing the official adoption of the 12° angle, from French Muslims official website)_](https://www.musulmansdefrance.fr/latitude-de-determination-de-lhoraire-du-ichaa-du-soubh/)
- [12 degrees of latitude for prayer times, an easier choice (in French) _(a muslim press article talking about the adoption of the 12° angle)_](https://www.saphirnews.com/La-Grande-Mosquee-de-Paris-garde-le-18e-degre-de-latitude-pour-les-horaires-de-priere_a14937.html)
- [References listed in abougouffa/pyIslam/docs/References.md](https://github.com/abougouffa/pyIslam/blob/master/docs/References.md)
- https://github.com/batoulapps/adhan-java